### PR TITLE
Added support for 12 Bit and fixed issue with ESP boards.

### DIFF
--- a/src/MSGEQ7.h
+++ b/src/MSGEQ7.h
@@ -36,7 +36,8 @@ THE SOFTWARE.
 
 // Use (optional) full 10 bit analog readings for MSGEQ7
 // TODO make this more useful with DUE an >10 bit ADC
-//#define MSGEQ7_10BIT
+// #define MSGEQ7_10BIT
+// #define MSGEQ7_12BIT
 
 // FPS makro
 #define ReadsPerSecond(f) (1000000UL / (f))
@@ -55,7 +56,13 @@ THE SOFTWARE.
 #define MSGEQ7_HIGH 5
 
 // Resolution dependant settings
-#ifdef MSGEQ7_10BIT
+#ifdef MSGEQ7_12BIT
+typedef uint16_t MSGEQ7_data_t;
+#define MSGEQ7_IN_MIN 320
+#define MSGEQ7_IN_MAX 4096
+#define MSGEQ7_OUT_MIN 0
+#define MSGEQ7_OUT_MAX 4096
+#elif defined(MSGEQ7_10BIT)
 typedef uint16_t MSGEQ7_data_t;
 #define MSGEQ7_IN_MIN 80
 #define MSGEQ7_IN_MAX 1023
@@ -73,7 +80,7 @@ typedef uint8_t MSGEQ7_data_t;
 inline MSGEQ7_data_t mapNoise(MSGEQ7_data_t x, MSGEQ7_data_t in_min = MSGEQ7_IN_MIN, MSGEQ7_data_t in_max = MSGEQ7_IN_MAX,
 		MSGEQ7_data_t out_min = MSGEQ7_OUT_MIN, MSGEQ7_data_t out_max = MSGEQ7_OUT_MAX);
 
-template <uint8_t smooth, uint8_t resetPin, uint8_t strobePin, uint8_t firstAnalogPin, uint8_t ...analogPins>
+template <uint16_t smooth, uint8_t resetPin, uint8_t strobePin, uint8_t firstAnalogPin, uint8_t ...analogPins>
 class CMSGEQ7{
 public:
 	CMSGEQ7(void);
@@ -104,6 +111,10 @@ private:
 		// little hack to take as many arguments as possible
 		// to execute several functions for the analogPins
 	}
+
+	// This calculates the value based on what MSGEQ7_data_t is defined.
+	// This assumes the analog pin resolution is 10 bit.
+	MSGEQ7_data_t getAnalogReadPin(uint8_t pin);
 };
 
 // implementation inline, moved to another .hpp file

--- a/src/MSGEQ7.h
+++ b/src/MSGEQ7.h
@@ -80,7 +80,7 @@ typedef uint8_t MSGEQ7_data_t;
 inline MSGEQ7_data_t mapNoise(MSGEQ7_data_t x, MSGEQ7_data_t in_min = MSGEQ7_IN_MIN, MSGEQ7_data_t in_max = MSGEQ7_IN_MAX,
 		MSGEQ7_data_t out_min = MSGEQ7_OUT_MIN, MSGEQ7_data_t out_max = MSGEQ7_OUT_MAX);
 
-template <uint16_t smooth, uint8_t resetPin, uint8_t strobePin, uint8_t firstAnalogPin, uint8_t ...analogPins>
+template <MSGEQ7_data_t smooth, uint8_t resetPin, uint8_t strobePin, uint8_t firstAnalogPin, uint8_t ...analogPins>
 class CMSGEQ7{
 public:
 	CMSGEQ7(void);
@@ -112,8 +112,7 @@ private:
 		// to execute several functions for the analogPins
 	}
 
-	// This calculates the value based on what MSGEQ7_data_t is defined.
-	// This assumes the analog pin resolution is 10 bit.
+	// This returns the value based on what MSGEQ7_data_t is defined.
 	MSGEQ7_data_t getAnalogReadPin(uint8_t pin);
 };
 

--- a/src/MSGEQ7.hpp
+++ b/src/MSGEQ7.hpp
@@ -231,6 +231,6 @@ getAnalogReadPin(uint8_t pin) {
 			read = max10BitVal;
 		}
 
-		return map(read, 0, max10BitVal, 0, __UINT8_MAX__);
+		return read >> 2;
 	#endif
 }

--- a/src/MSGEQ7.hpp
+++ b/src/MSGEQ7.hpp
@@ -52,7 +52,7 @@ MSGEQ7_data_t mapNoise(MSGEQ7_data_t x, MSGEQ7_data_t in_min, MSGEQ7_data_t in_m
 //================================================================================
 
 // initialize the instance's variables
-template <uint8_t smooth, uint8_t resetPin, uint8_t strobePin, uint8_t firstAnalogPin, uint8_t ...analogPins>
+template <uint16_t smooth, uint8_t resetPin, uint8_t strobePin, uint8_t firstAnalogPin, uint8_t ...analogPins>
 CMSGEQ7<smooth, resetPin, strobePin, firstAnalogPin, analogPins ...>::
 CMSGEQ7(void)
 {
@@ -64,7 +64,7 @@ CMSGEQ7(void)
 // IC setup
 //================================================================================
 
-template <uint8_t smooth, uint8_t resetPin, uint8_t strobePin, uint8_t firstAnalogPin, uint8_t ...analogPins>
+template <uint16_t smooth, uint8_t resetPin, uint8_t strobePin, uint8_t firstAnalogPin, uint8_t ...analogPins>
 void CMSGEQ7<smooth, resetPin, strobePin, firstAnalogPin, analogPins ...>::
 begin(void){
 	// do whatever is required to initialize the IC
@@ -74,7 +74,7 @@ begin(void){
 	nop((pinMode(analogPins, INPUT), 0)...);
 }
 
-template <uint8_t smooth, uint8_t resetPin, uint8_t strobePin, uint8_t firstAnalogPin, uint8_t ...analogPins>
+template <uint16_t smooth, uint8_t resetPin, uint8_t strobePin, uint8_t firstAnalogPin, uint8_t ...analogPins>
 void CMSGEQ7<smooth, resetPin, strobePin, firstAnalogPin, analogPins ...>::
 end(void){
 	// set pins to input again to safely remove connections if needed
@@ -84,7 +84,7 @@ end(void){
 	nop((pinMode(analogPins, INPUT), 0)...);
 }
 
-template <uint8_t smooth, uint8_t resetPin, uint8_t strobePin, uint8_t firstAnalogPin, uint8_t ...analogPins>
+template <uint16_t smooth, uint8_t resetPin, uint8_t strobePin, uint8_t firstAnalogPin, uint8_t ...analogPins>
 void CMSGEQ7<smooth, resetPin, strobePin, firstAnalogPin, analogPins ...>::
 reset(void){
 	// only this setting seems to works properly
@@ -98,7 +98,7 @@ reset(void){
 // read
 //================================================================================
 
-template <uint8_t smooth, uint8_t resetPin, uint8_t strobePin, uint8_t firstAnalogPin, uint8_t ...analogPins>
+template <uint16_t smooth, uint8_t resetPin, uint8_t strobePin, uint8_t firstAnalogPin, uint8_t ...analogPins>
 bool CMSGEQ7<smooth, resetPin, strobePin, firstAnalogPin, analogPins ...>::
 read(void){
 	// reset the IC frequently, otherwise it will get out of sync after a while
@@ -116,13 +116,8 @@ read(void){
 
 		// read pins with 8 bit resolution
 		frequency f = (frequency){
-#ifdef MSGEQ7_10BIT
-			analogRead(firstAnalogPin),
-				analogRead(analogPins)...
-#else
-			MSGEQ7_data_t(analogRead(firstAnalogPin) >> 2),
-				MSGEQ7_data_t(analogRead(analogPins) >> 2)...
-#endif
+			getAnalogReadPin(firstAnalogPin),
+			getAnalogReadPin(analogPins)...
 		};
 
 		// Save smooth values
@@ -133,7 +128,7 @@ read(void){
 					frequencies[i].pin[p]++;
 
 				// Smooth value
-				frequencies[i].pin[p] = uint16_t(frequencies[i].pin[p] * smooth + f.pin[p] * (255 - smooth)) / 255;
+				frequencies[i].pin[p] = uint32_t(frequencies[i].pin[p] * smooth + f.pin[p] * (MSGEQ7_OUT_MAX - smooth)) / MSGEQ7_OUT_MAX;
 			}
 		}
 		// Save peek values
@@ -144,7 +139,7 @@ read(void){
 	return true;
 }
 
-template <uint8_t smooth, uint8_t resetPin, uint8_t strobePin, uint8_t firstAnalogPin, uint8_t ...analogPins>
+template <uint16_t smooth, uint8_t resetPin, uint8_t strobePin, uint8_t firstAnalogPin, uint8_t ...analogPins>
 bool CMSGEQ7<smooth, resetPin, strobePin, firstAnalogPin, analogPins ...>::
 read(const uint32_t interval){
 	// Read without delay
@@ -166,7 +161,7 @@ read(const uint32_t interval){
 // get values
 //================================================================================
 
-template <uint8_t smooth, uint8_t resetPin, uint8_t strobePin, uint8_t firstAnalogPin, uint8_t ...analogPins>
+template <uint16_t smooth, uint8_t resetPin, uint8_t strobePin, uint8_t firstAnalogPin, uint8_t ...analogPins>
 MSGEQ7_data_t CMSGEQ7<smooth, resetPin, strobePin, firstAnalogPin, analogPins ...>::
 get(const uint8_t frequency, const uint8_t channel){
 	// dont read out of bounds
@@ -177,7 +172,7 @@ get(const uint8_t frequency, const uint8_t channel){
 	return frequencies[frequency].pin[channel];
 }
 
-template <uint8_t smooth, uint8_t resetPin, uint8_t strobePin, uint8_t firstAnalogPin, uint8_t ...analogPins>
+template <uint16_t smooth, uint8_t resetPin, uint8_t strobePin, uint8_t firstAnalogPin, uint8_t ...analogPins>
 MSGEQ7_data_t CMSGEQ7<smooth, resetPin, strobePin, firstAnalogPin, analogPins ...>::
 get(const uint8_t frequency){
 	// dont read out of bounds
@@ -193,7 +188,7 @@ get(const uint8_t frequency){
 	return (average / (1 + sizeof...(analogPins)));
 }
 
-template <uint8_t smooth, uint8_t resetPin, uint8_t strobePin, uint8_t firstAnalogPin, uint8_t ...analogPins>
+template <uint16_t smooth, uint8_t resetPin, uint8_t strobePin, uint8_t firstAnalogPin, uint8_t ...analogPins>
 MSGEQ7_data_t CMSGEQ7<smooth, resetPin, strobePin, firstAnalogPin, analogPins ...>::
 getVolume(uint8_t channel){
 	// dont read out of bounds
@@ -209,7 +204,7 @@ getVolume(uint8_t channel){
 	return vol / 7;
 }
 
-template <uint8_t smooth, uint8_t resetPin, uint8_t strobePin, uint8_t firstAnalogPin, uint8_t ...analogPins>
+template <uint16_t smooth, uint8_t resetPin, uint8_t strobePin, uint8_t firstAnalogPin, uint8_t ...analogPins>
 MSGEQ7_data_t CMSGEQ7<smooth, resetPin, strobePin, firstAnalogPin, analogPins ...>::
 getVolume(void){
 	// add all frequencies of all channels to the overall volume
@@ -219,4 +214,23 @@ getVolume(void){
 
 	// return the average of all channels
 	return vol / 7;
+}
+
+template <uint16_t smooth, uint8_t resetPin, uint8_t strobePin, uint8_t firstAnalogPin, uint8_t ...analogPins>
+MSGEQ7_data_t CMSGEQ7<smooth, resetPin, strobePin, firstAnalogPin, analogPins ...>::
+getAnalogReadPin(uint8_t pin) {
+	// This assumes the analogReadResolution is already at 10 bit.
+	int read = analogRead(pin);
+	#if defined(MSGEQ7_10BIT) || defined(MSGEQ7_12BIT)
+		// Return the value as int.
+		return read;
+	#else
+		// get max resolution of analog pin and map it to 8 bit range. Some systems, esp8266, have range from 0 - 1024 so there is a max range of 1023.
+		uint16_t max10BitVal = 1023;
+		if (read > max10BitVal) {
+			read = max10BitVal;
+		}
+
+		return map(read, 0, max10BitVal, 0, __UINT8_MAX__);
+	#endif
 }

--- a/src/MSGEQ7.hpp
+++ b/src/MSGEQ7.hpp
@@ -52,7 +52,7 @@ MSGEQ7_data_t mapNoise(MSGEQ7_data_t x, MSGEQ7_data_t in_min, MSGEQ7_data_t in_m
 //================================================================================
 
 // initialize the instance's variables
-template <uint16_t smooth, uint8_t resetPin, uint8_t strobePin, uint8_t firstAnalogPin, uint8_t ...analogPins>
+template <MSGEQ7_data_t smooth, uint8_t resetPin, uint8_t strobePin, uint8_t firstAnalogPin, uint8_t ...analogPins>
 CMSGEQ7<smooth, resetPin, strobePin, firstAnalogPin, analogPins ...>::
 CMSGEQ7(void)
 {
@@ -64,7 +64,7 @@ CMSGEQ7(void)
 // IC setup
 //================================================================================
 
-template <uint16_t smooth, uint8_t resetPin, uint8_t strobePin, uint8_t firstAnalogPin, uint8_t ...analogPins>
+template <MSGEQ7_data_t smooth, uint8_t resetPin, uint8_t strobePin, uint8_t firstAnalogPin, uint8_t ...analogPins>
 void CMSGEQ7<smooth, resetPin, strobePin, firstAnalogPin, analogPins ...>::
 begin(void){
 	// do whatever is required to initialize the IC
@@ -74,7 +74,7 @@ begin(void){
 	nop((pinMode(analogPins, INPUT), 0)...);
 }
 
-template <uint16_t smooth, uint8_t resetPin, uint8_t strobePin, uint8_t firstAnalogPin, uint8_t ...analogPins>
+template <MSGEQ7_data_t smooth, uint8_t resetPin, uint8_t strobePin, uint8_t firstAnalogPin, uint8_t ...analogPins>
 void CMSGEQ7<smooth, resetPin, strobePin, firstAnalogPin, analogPins ...>::
 end(void){
 	// set pins to input again to safely remove connections if needed
@@ -84,7 +84,7 @@ end(void){
 	nop((pinMode(analogPins, INPUT), 0)...);
 }
 
-template <uint16_t smooth, uint8_t resetPin, uint8_t strobePin, uint8_t firstAnalogPin, uint8_t ...analogPins>
+template <MSGEQ7_data_t smooth, uint8_t resetPin, uint8_t strobePin, uint8_t firstAnalogPin, uint8_t ...analogPins>
 void CMSGEQ7<smooth, resetPin, strobePin, firstAnalogPin, analogPins ...>::
 reset(void){
 	// only this setting seems to works properly
@@ -98,7 +98,7 @@ reset(void){
 // read
 //================================================================================
 
-template <uint16_t smooth, uint8_t resetPin, uint8_t strobePin, uint8_t firstAnalogPin, uint8_t ...analogPins>
+template <MSGEQ7_data_t smooth, uint8_t resetPin, uint8_t strobePin, uint8_t firstAnalogPin, uint8_t ...analogPins>
 bool CMSGEQ7<smooth, resetPin, strobePin, firstAnalogPin, analogPins ...>::
 read(void){
 	// reset the IC frequently, otherwise it will get out of sync after a while
@@ -114,7 +114,6 @@ read(void){
 		// allow the output to settle
 		delayMicroseconds(36);
 
-		// read pins with 8 bit resolution
 		frequency f = (frequency){
 			getAnalogReadPin(firstAnalogPin),
 			getAnalogReadPin(analogPins)...
@@ -139,7 +138,7 @@ read(void){
 	return true;
 }
 
-template <uint16_t smooth, uint8_t resetPin, uint8_t strobePin, uint8_t firstAnalogPin, uint8_t ...analogPins>
+template <MSGEQ7_data_t smooth, uint8_t resetPin, uint8_t strobePin, uint8_t firstAnalogPin, uint8_t ...analogPins>
 bool CMSGEQ7<smooth, resetPin, strobePin, firstAnalogPin, analogPins ...>::
 read(const uint32_t interval){
 	// Read without delay
@@ -161,7 +160,7 @@ read(const uint32_t interval){
 // get values
 //================================================================================
 
-template <uint16_t smooth, uint8_t resetPin, uint8_t strobePin, uint8_t firstAnalogPin, uint8_t ...analogPins>
+template <MSGEQ7_data_t smooth, uint8_t resetPin, uint8_t strobePin, uint8_t firstAnalogPin, uint8_t ...analogPins>
 MSGEQ7_data_t CMSGEQ7<smooth, resetPin, strobePin, firstAnalogPin, analogPins ...>::
 get(const uint8_t frequency, const uint8_t channel){
 	// dont read out of bounds
@@ -172,7 +171,7 @@ get(const uint8_t frequency, const uint8_t channel){
 	return frequencies[frequency].pin[channel];
 }
 
-template <uint16_t smooth, uint8_t resetPin, uint8_t strobePin, uint8_t firstAnalogPin, uint8_t ...analogPins>
+template <MSGEQ7_data_t smooth, uint8_t resetPin, uint8_t strobePin, uint8_t firstAnalogPin, uint8_t ...analogPins>
 MSGEQ7_data_t CMSGEQ7<smooth, resetPin, strobePin, firstAnalogPin, analogPins ...>::
 get(const uint8_t frequency){
 	// dont read out of bounds
@@ -188,7 +187,7 @@ get(const uint8_t frequency){
 	return (average / (1 + sizeof...(analogPins)));
 }
 
-template <uint16_t smooth, uint8_t resetPin, uint8_t strobePin, uint8_t firstAnalogPin, uint8_t ...analogPins>
+template <MSGEQ7_data_t smooth, uint8_t resetPin, uint8_t strobePin, uint8_t firstAnalogPin, uint8_t ...analogPins>
 MSGEQ7_data_t CMSGEQ7<smooth, resetPin, strobePin, firstAnalogPin, analogPins ...>::
 getVolume(uint8_t channel){
 	// dont read out of bounds
@@ -204,7 +203,7 @@ getVolume(uint8_t channel){
 	return vol / 7;
 }
 
-template <uint16_t smooth, uint8_t resetPin, uint8_t strobePin, uint8_t firstAnalogPin, uint8_t ...analogPins>
+template <MSGEQ7_data_t smooth, uint8_t resetPin, uint8_t strobePin, uint8_t firstAnalogPin, uint8_t ...analogPins>
 MSGEQ7_data_t CMSGEQ7<smooth, resetPin, strobePin, firstAnalogPin, analogPins ...>::
 getVolume(void){
 	// add all frequencies of all channels to the overall volume
@@ -216,21 +215,20 @@ getVolume(void){
 	return vol / 7;
 }
 
-template <uint16_t smooth, uint8_t resetPin, uint8_t strobePin, uint8_t firstAnalogPin, uint8_t ...analogPins>
+template <MSGEQ7_data_t smooth, uint8_t resetPin, uint8_t strobePin, uint8_t firstAnalogPin, uint8_t ...analogPins>
 MSGEQ7_data_t CMSGEQ7<smooth, resetPin, strobePin, firstAnalogPin, analogPins ...>::
 getAnalogReadPin(uint8_t pin) {
-	// This assumes the analogReadResolution is already at 10 bit.
 	int read = analogRead(pin);
 	#if defined(MSGEQ7_10BIT) || defined(MSGEQ7_12BIT)
 		// Return the value as int.
 		return read;
 	#else
-		// get max resolution of analog pin and map it to 8 bit range. Some systems, esp8266, have range from 0 - 1024 so there is a max range of 1023.
+		// Some systems, esp8266, have range from 0 - 1024 so there is a max range of 1023.
 		uint16_t max10BitVal = 1023;
 		if (read > max10BitVal) {
 			read = max10BitVal;
 		}
-
+		
 		return read >> 2;
 	#endif
 }


### PR DESCRIPTION
- Fixed issue with some ESP boards returning 0 when the audio was max value. This was caused by analogRead returning 1024 for some esp boards, and shifting to 2 bits to the right would return 256 and casting it to uint8_t would return 0. More info of the issue here: https://github.com/NicoHood/MSGEQ7/issues/14
- change smooth type to uint16 to support 10 and 12 Bit.
- changed casting of smoothing algorithm to uint32 to support 10 and 12 bit smoothing.

Should I implement analogReadResolution in the future? For some systems like AVR Duo or ESP32 who support 12 bit?